### PR TITLE
Исправлена опечатка в комментарии о размерности

### DIFF
--- a/assignments/assignment1/KNN.ipynb
+++ b/assignments/assignment1/KNN.ipynb
@@ -112,7 +112,7 @@
     "binary_test_X = test_X[binary_test_mask]\n",
     "binary_test_y = test_y[binary_test_mask] == 0\n",
     "\n",
-    "# Reshape to 1-dimensional array [num_samples, 3*3*32]\n",
+    "# Reshape to 1-dimensional array [num_samples, 32*32*3]\n",
     "binary_train_X = binary_train_X.reshape(binary_train_X.shape[0], -1)\n",
     "binary_test_X = binary_test_X.reshape(binary_test_X.shape[0], -1)"
    ]


### PR DESCRIPTION
binary_train_X после reshape будет не  `[num_samples, 3*3*32]`,  а `[num_samples, 32*32*3]`