### PR TITLE
wrong shape of target_index

### DIFF
--- a/assignments/assignment1/Linear classifier.ipynb
+++ b/assignments/assignment1/Linear classifier.ipynb
@@ -259,7 +259,7 @@
     "num_classes = 4\n",
     "batch_size = 3\n",
     "predictions = np.random.randint(-1, 3, size=(batch_size, num_classes)).astype(np.float)\n",
-    "target_index = np.random.randint(0, num_classes, size=(batch_size, 1)).astype(np.int)\n",
+    "target_index = np.random.randint(0, num_classes, size=(batch_size,)).astype(np.int)\n",
     "check_gradient(lambda x: linear_classifer.softmax_with_cross_entropy(x, target_index), predictions)\n",
     "\n",
     "# Make sure maximum subtraction for numberic stability is done separately for every sample in the batch\n",


### PR DESCRIPTION
I think  _target_index_ should be vector, not matrix. Because we expect that target values in the batch will be represented as vector.